### PR TITLE
updated to use project name variable

### DIFF
--- a/GitLabCICD/gitlab-npm.yml
+++ b/GitLabCICD/gitlab-npm.yml
@@ -11,7 +11,7 @@ dependency_scanning:
     # Run snyk help, snyk auth, snyk monitor, snyk test to break build and out report
     - snyk --help
     - snyk auth $SNYK_TOKEN
-    - snyk monitor --project-name=goof-gitlab
+    - snyk monitor --project-name=$CI_PROJECT_NAME
     - snyk test --json | snyk-to-html -o snyk_results.html
  
   # Save report to artifacts


### PR DESCRIPTION
replacing `goof-gitlab` with `$CI_PROJECT_NAME`. This will allow the pipeline to succeed without imperative coding, while declaring the correct project name.

see the GitLab predefined variables for more info https://docs.gitlab.com/ee/ci/variables/predefined_variables.html