### PR TITLE
updated `--project-name` arg

### DIFF
--- a/GitLabCICD/gitlab-python.yml
+++ b/GitLabCICD/gitlab-python.yml
@@ -35,5 +35,5 @@ dependency_scanning:
     - npm install -g snyk
     # Run snyk auth, snyk monitor, snyk test to break build and output report
     - snyk auth $SNYK_TOKEN
-    - snyk monitor --project-name=python-goof_GitLab_CI/CD
+    - snyk monitor --project-name=$CI_PROJECT_NAME
     - snyk test


### PR DESCRIPTION
### Description
- replaced `python-goof_GitLab_CI/CD` with `$CI_PROJECT_NAME`
	- the forward-slash `/` used in `python-goof_GitLab_CI/CD` is not escaped and not usable
	- `$CI_PROJECT_NAME` is a native GitLab variable that defines the project name

### Useful Links
https://docs.gitlab.com/ee/ci/variables/predefined_variables.html