### PR TITLE
Update GH-actions-pipeline-npm-nodejs-sarif.yml

### DIFF
--- a/GitHub/GH-actions-pipeline-npm-nodejs-sarif.yml
+++ b/GitHub/GH-actions-pipeline-npm-nodejs-sarif.yml
@@ -35,7 +35,7 @@ jobs:
       run: snyk test --org=${{ secrets.SNYK_ORG }} --all-projects --sarif-file-output=snyk-oss.sarif
       continue-on-error: true
     - name: Upload results to GitHub Open Source Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: snyk-oss.sarif
 
@@ -43,7 +43,7 @@ jobs:
       run: snyk code test --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk-code.sarif
       continue-on-error: true
     - name: Upload results to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: snyk-code.sarif
 
@@ -54,7 +54,7 @@ jobs:
       run: snyk container test --org=${{ secrets.SNYK_ORG }} --file=Dockerfile --sarif-file-output=snyk-container.sarif sebsnyk/juice-shop:latest
       continue-on-error: true
     - name: Upload results to GitHub Container Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: snyk-container.sarif
 
@@ -62,7 +62,7 @@ jobs:
       run: snyk iac test --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk-iac.sarif
       continue-on-error: true
     - name: Upload results to GitHub IaC Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: snyk-iac.sarif
         


### PR DESCRIPTION
This version of the CodeQL Action was deprecated on January 18th, 2023, and is no longer updated or supported. For better performance, improved security, and new features, upgrade to v2. For more information, see https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/