### PR TITLE
fixed npm based pipeline example 

### DIFF
--- a/GitLabCICD/gitlab-npm.yml
+++ b/GitLabCICD/gitlab-npm.yml
@@ -8,6 +8,8 @@ dependency_scanning:
     - npm install -g npm@latest
     - npm install -g snyk
     - npm install snyk-to-html -g
+    # install dependencies for the project 
+    - npm install 
     # Run snyk help, snyk auth, snyk monitor, snyk test to break build and out report
     - snyk --help
     - snyk auth $SNYK_TOKEN


### PR DESCRIPTION
without installing dependencies prior to scan snyk is unable to identify components, to fix it you need to run `npm install` before SCA scan 